### PR TITLE
[ci skip] [skip ci] ***NO_CI*** Update maintainers, remove conda-forge/napari

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,4 +144,5 @@ Feedstock Maintainers
 =====================
 
 * [@spreka](https://github.com/spreka/)
-
+* [@goanpeca](https://github.com/goanpeca/)
+* [@jaimergp](https://github.com/jaimergp/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,3 +49,5 @@ about:
 extra:
   recipe-maintainers:
     - spreka
+    - goanpeca
+    - jaimergp


### PR DESCRIPTION
The `conda-forge/napari` team was initially added as a way to support the migration to conda-forge.

The situation is now stable and we can prevent unwanted notifications by only leaving a subset of the team listed explicitly as maintainers.