### PR TITLE
fix win-64 tensorflow dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: 4e841264004c8e732f10e4f8792631d7cd39d141ea8b987d92f128da54f2ee52
 
 build:
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   number: 1
 
@@ -27,8 +26,8 @@ requirements:
     - python >=3.7
     - roifile
     - scikit-image
-    - tensorflow >=2.5.0 # [not win]
-    - tensorflow-gpu >=2.5.0 # [win]
+    - tensorflow >=2.5.0  # [not win]
+    - tensorflow-gpu >=2.5.0  # [win]
     - tifffile
     - qtpy
     - napari

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -27,7 +27,8 @@ requirements:
     - python >=3.7
     - roifile
     - scikit-image
-    - tensorflow >=2.5.0
+    - tensorflow >=2.5.0 # [not win]
+    - tensorflow-gpu >=2.5.0 # [win]
     - tifffile
     - qtpy
     - napari


### PR DESCRIPTION
A separate tensorflow dependency is added for win-64 to fix package not found error when installing with conda on Windows.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
